### PR TITLE
Set Matplotlib backend to Agg before pyplot import

### DIFF
--- a/scripts/generate_report.py
+++ b/scripts/generate_report.py
@@ -19,6 +19,8 @@ Note: URLs/APIs may change. Adjust fetch functions accordingly.
 import os
 import numpy as np
 import pandas as pd
+import matplotlib
+matplotlib.use("Agg")
 from matplotlib import pyplot as plt
 from matplotlib.backends.backend_pdf import PdfPages
 from datetime import datetime


### PR DESCRIPTION
## Summary
- Configure Matplotlib to use the non-interactive Agg backend in the report generation script, allowing plots to be rendered without a display.

## Testing
- `python -m py_compile scripts/generate_report.py`
- `python scripts/generate_report.py`


------
https://chatgpt.com/codex/tasks/task_e_689c71c02bec8321b82fbc2fc50f8a0d