### PR TITLE
fix: force-add report artifacts in workflow

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -34,10 +34,15 @@ jobs:
         run: |
           python scripts/generate_report.py
 
-      - name: Commit report
+      - name: Commit report (force add)
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add reports/research_report.pdf reports/*.png data/climate_dataset.csv
-          git commit -m "chore: auto-generate report $(date -u +'%Y-%m-%d %H:%M:%S')" || echo "No changes to commit."
-          git push origin HEAD:main
+          git add -f data/climate_dataset.csv reports/*.png reports/*.pdf
+          if ! git diff --cached --quiet; then
+            git pull --rebase origin "${GITHUB_REF_NAME}"
+            git commit -m "chore: auto-generate report $(date -u +'%Y-%m-%d %H:%M:%S')"
+            git push
+          else
+            echo "No changes to commit."
+          fi


### PR DESCRIPTION
## Summary
- ensure GitHub Actions commits generated datasets and report images with force add

## Testing
- `python -m pytest`
- `GITHUB_REF_NAME=work bash -e <<'EOF'
  git config user.name "github-actions[bot]"
  git config user.email "github-actions[bot]@users.noreply.github.com"
  git add -f data/climate_dataset.csv reports/*.png reports/*.pdf
  if ! git diff --cached --quiet; then
    git pull --rebase origin "${GITHUB_REF_NAME}"
    git commit -m "chore: auto-generate report $(date -u +'%Y-%m-%d %H:%M:%S')"
    git push
  else
    echo "No changes to commit."
  fi
EOF`


------
https://chatgpt.com/codex/tasks/task_e_689c76ca7e7c8321a3c649d9d1fddb82