### PR TITLE
fix: correct workflow indentation

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           python scripts/generate_report.py
 
-       - name: Commit report (force add)
+      - name: Commit report (force add)
         shell: bash
         run: |
           set -eo pipefail


### PR DESCRIPTION
## Summary
- fix indentation of commit step in report workflow so YAML parses

## Testing
- `pytest`
- `pip install pyyaml` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_689c7b22c23c832181b037194ae75710