### PR TITLE
feat: add continental climate analysis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 
-pandas
-numpy
-matplotlib
-requests
 geopandas
+matplotlib
+numpy
+pandas
 pycountry-convert
+requests


### PR DESCRIPTION
## Summary
- support loading and caching of Berkeley Earth country data and NOAA CO₂ data grouped by continent
- compute per-continent climate trends and generate regional figures and heatmap
- integrate regional section with visuals into PDF report
- sort dependencies and ensure requests/geopandas/pycountry-convert are listed

## Testing
- `python scripts/generate_report.py` *(fails to download regional data due to network; global report generated)*

------
https://chatgpt.com/codex/tasks/task_e_689c8960dba8832182cc7fc0d22041bb