### PR TITLE
fix: resolve syntax error in workflow

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -30,13 +30,18 @@ jobs:
           python scripts/generate_report.py
 
       - name: Commit CSV only
+        shell: bash
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add data/*.csv
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update CSV climate data $(date -u +'%Y-%m-%d %H:%M:%S')"
-            git push
-          else
+
+          git add data/*.csv 2>/dev/null || true
+
+          if git diff --cached --quiet; then
             echo "No CSV changes."
+          else
+            git commit -m "chore: update CSV climate data $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            git push
+          fi
 


### PR DESCRIPTION
## Summary
- use bash and strict error handling in `Commit CSV only` step
- properly add CSV files and commit with UTC timestamp

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ca47e466483219e06776b73306cbb